### PR TITLE
Update config.yaml to include 'SoundEdition' in each of the networks

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -15,15 +15,18 @@ networks:
       - name: SoundCreatorV2
         address:
           - '0x0000000000aec84F5BFc2af15EAfb943bf4e3522'
+      - name: SoundEdition
   - id: 10
     start_block: 0
     contracts:
       - name: SoundCreatorV2
         address:
           - '0x0000000000aec84F5BFc2af15EAfb943bf4e3522'
+      - name: SoundEdition
   - id: 8453
     start_block: 0
     contracts:
       - name: SoundCreatorV2
         address:
           - '0x0000000000aec84F5BFc2af15EAfb943bf4e3522'
+      - name: SoundEdition


### PR DESCRIPTION
Please note, I haven't run this code yet. My colleague noticed the same issue earlier so this would be the fix.

We need to improve the error messages and communication around this so it doesn't catch other people out.

There is definitely an inconsistency with the codegen output how we have it too, since you have access to the creation of the dynamic contract even if it isn't registered on the chain.